### PR TITLE
Potential fix for code scanning alert no. 19: Code injection

### DIFF
--- a/app/controllers/ops/admin_controller.rb
+++ b/app/controllers/ops/admin_controller.rb
@@ -335,7 +335,9 @@ module Ops
 
     # Advanced: StructuredLogger test with level, message, payload, and force toggle
     def axiom_log_test
-      level = params[:level].to_s.presence || "info"
+      allowed_levels = %w[debug info warn error fatal unknown]
+      level_param = params[:level].to_s.presence
+      level = allowed_levels.include?(level_param) ? level_param : "info"
       message = params[:message].to_s.presence || "ops_axiom_test"
       force = ActiveModel::Type::Boolean.new.cast(params[:force])
       payload_json = params[:payload].to_s


### PR DESCRIPTION
Potential fix for [https://github.com/TecHub-life/techub/security/code-scanning/19](https://github.com/TecHub-life/techub/security/code-scanning/19)

The best way to fix this issue is to restrict the user-supplied `level` parameter to a predefined, safe, and minimal set of log levels, rather than using whatever string the user provides. For instance, only allow `level` values of "info", "warn", "error", "debug", etc. The code should check `level` against this list and use a default if the input is not valid. Specifically, in `axiom_log_test`, just after obtaining `level` from `params`, filter it against a constant array of allowed log levels and default to "info" (or another safe value) if it doesn't match. This change is self-contained and does not alter external behaviour except to improve safety.

Required changes:
- Define a constant array of allowed log levels.
- Filter the user-supplied `level` against this array immediately after it is obtained from `params[:level]`.
- Use the filtered—and therefore trusted—`level` onward in the method.

No imports are needed; only Ruby standard syntax and conventions are used. All changes are made in the method shown within the controller file app/controllers/ops/admin_controller.rb.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
